### PR TITLE
Delegate to Azure SDK to remove registrations by device handle

### DIFF
--- a/Softeq.NetKit.Services.PushNotifications/Softeq.NetKit.Services.PushNotifications.csproj
+++ b/Softeq.NetKit.Services.PushNotifications/Softeq.NetKit.Services.PushNotifications.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.1.1</Version>
+    <Version>1.2.0</Version>
     <Description></Description>
     <Authors>Softeq Development Corp.</Authors>
     <Company>Softeq Development Corp.</Company>
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="8.1.1" />
-    <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="3.0.1" />
+    <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="3.3.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
On our project, we face the following exceptions coming from the underlying SDK sometimes.

```
The messaging entity ' .TrackingId:492cc6ee-3e68-45b2-8b04-f08fefe60fc7_G1,TimeStamp:6/4/2020 2:56:09 PM' could not be found.
```
I believe this is happening due to occasional race conditions, e.g. when a mobile app submits 2 subsequent subscribe requests in a row without waiting on the result of the first one. In this case, we are not interested to fail the whole response with a 500 error as we care only about the final result: the device should be registered if all provided information was correct.

Hopefully, this PR should handle such cases. I've done the following things:
- Bumped the dependency to the latest version
- Used `DeleteRegistrationsByChannel` from the SDK instead of custom one listing and then deletion
- Added some resiliency to catch "NotFound" responses and ignore them

I would also like to log "NotFound" responses, but currently, the library doesn't provide any logging integration possibilities, so I decided not to do it so far.